### PR TITLE
CI: drop Go 1.3 and add 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 go:
-  - 1.3
   - 1.4
   - 1.5
+  - 1.6
 script:
   - go test -coverprofile=coverage.txt -covermode=atomic
 after_success:


### PR DESCRIPTION
It seems Gorilla has stopped supporting 1.3, and in the meantime, 1.6 was released. Time for a CI update.
